### PR TITLE
PDC updates

### DIFF
--- a/container_images.config
+++ b/container_images.config
@@ -4,7 +4,7 @@ params {
         diann:                 'quay.io/protio/diann:1.8.1',
         bibliospec:            'quay.io/protio/bibliospec-linux:3.0',
         panorama_client:       'quay.io/protio/panorama-client:1.1.0',
-        pdc_client:            'quay.io/mauraisa/pdc_client:2.3.2',
+        pdc_client:            'quay.io/mauraisa/pdc_client:2.3.3',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
         qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.6.2',

--- a/container_images.config
+++ b/container_images.config
@@ -4,7 +4,7 @@ params {
         diann:                 'quay.io/protio/diann:1.8.1',
         bibliospec:            'quay.io/protio/bibliospec-linux:3.0',
         panorama_client:       'quay.io/protio/panorama-client:1.1.0',
-        pdc_client:            'quay.io/mauraisa/pdc_client:2.3.0',
+        pdc_client:            'quay.io/mauraisa/pdc_client:2.3.2',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
         qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.6.2',

--- a/container_images.config
+++ b/container_images.config
@@ -8,7 +8,7 @@ params {
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
         qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.6.2',
-        proteowizard:          'quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.0.9.97-ae4c997',
+        proteowizard:          'quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.1.1.270-67f3e15',
         cascadia:              'quay.io/protio/cascadia:0.0.7',
         cascadia_utils:        'quay.io/protio/cascadia-utils:0.0.4',
         carafe:                'quay.io/mauraisa/carafe:0.0.1-beta'

--- a/container_images.config
+++ b/container_images.config
@@ -7,7 +7,7 @@ params {
         pdc_client:            'quay.io/mauraisa/pdc_client:2.3.3',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
-        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.6.2',
+        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.7.0',
         proteowizard:          'quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.1.1.270-67f3e15',
         cascadia:              'quay.io/protio/cascadia:0.0.7',
         cascadia_utils:        'quay.io/protio/cascadia-utils:0.0.4',

--- a/modules/msconvert.nf
+++ b/modules/msconvert.nf
@@ -90,7 +90,20 @@ process UNZIP_DIRECTORY {
 
     script:
         """
-        unzip ${zip_file}
+        base="${zip_file.baseName}"
+        tmpdir=\$(mktemp -d)
+
+        unzip "${zip_file}" -d "\$tmpdir"
+
+        found=\$(find "\$tmpdir" -type d -name "\$base" -print -quit)
+        if [ -z "\$found" ]; then
+           echo "ERROR: Could not locate directory '\$base' inside archive ${zip_file}" >&2
+           echo "Archive listing:" >&2
+           unzip -l "${zip_file}" >&2
+           exit 1
+        fi
+
+        mv "\$found" "./\$base"
         """
 
     stub:

--- a/modules/pdc.nf
+++ b/modules/pdc.nf
@@ -76,7 +76,9 @@ process GET_FILE {
 
     script:
         """
-        PDC_client file -o '${file_name}' --size '${file_size}' --md5sum '${md5}' --url '${url}'
+        PDC_client file -o '${file_name}' \
+            --size '${file_size}' --md5sum '${md5}' --url '${url}' \
+            ${ params.pdc.s3_download ? format_flag(params.aws.batch.cliPath, '--aws-cli') : '' }
         """
 
     stub:

--- a/modules/pdc.nf
+++ b/modules/pdc.nf
@@ -3,7 +3,7 @@ include { format_flag } from "./utils.nf"
 
 process GET_STUDY_METADATA {
     publishDir "${params.result_dir}/pdc", failOnError: true, mode: 'copy'
-    errorStrategy 'retry'
+    errorStrategy { sleep(Math.pow(2, task.attempt) * 15 as long); return 'retry' }
     maxRetries 5
     label 'process_low_constant'
     container params.images.pdc_client
@@ -23,7 +23,17 @@ process GET_STUDY_METADATA {
 
         """
         export study_id=\$(PDC_client studyID ${pdc_client_args} ${pdc_study_id} | tee study_id.txt)
+        if [ -z "\$study_id" ]; then
+            echo "Failed to retrieve study_id"
+            exit 1
+        fi
+
         export study_name=\$(PDC_client studyName --normalize ${pdc_client_args} \$study_id | tee study_name.txt)
+        if [ -z "\$study_name" ]; then
+            echo "Failed to retrieve study_name"
+            exit 1
+        fi
+
         PDC_client metadata ${pdc_client_args} \
             --flatten -f json --skylineAnnotations \$study_id \
             ${format_flag(params.pdc.n_raw_files, "--nFiles")} ${params.pdc.s3_download ? "--s3Path" : ""}

--- a/modules/skyline.nf
+++ b/modules/skyline.nf
@@ -183,14 +183,14 @@ process SKYLINE_MERGE_RESULTS {
         --share-type="complete" \
         > >(tee 'skyline-merge.stdout') 2> >(tee 'skyline-merge.stderr' >&2)
 
-    md5sum ${skyline_document_name}.sky.zip | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
+    md5sum "${skyline_document_name}.sky.zip" | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
     """
 
     stub:
     """
     touch "${skyline_document_name}.sky.zip"
     touch "skyline-merge.stderr" "skyline-merge.stdout"
-    md5sum ${skyline_document_name}.sky.zip | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
+    md5sum "${skyline_document_name}.sky.zip" | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
     """
 }
 
@@ -247,14 +247,14 @@ process SKYLINE_MINIMIZE_DOCUMENT {
             --share-type="minimal" \
         > >(tee 'minimize_skyline.stdout') 2> >(tee 'minimize_skyline.stderr' >&2)
 
-        md5sum ${sky_basename(skyline_zipfile)}_minimized.sky.zip | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
+        md5sum "${sky_basename(skyline_zipfile)}_minimized.sky.zip" | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
         """
 
     stub:
     """
-    touch ${sky_basename(skyline_zipfile)}_minimized.sky.zip
+    touch "${sky_basename(skyline_zipfile)}_minimized.sky.zip"
     touch stub.stdout stub.stderr
-    md5sum ${sky_basename(skyline_zipfile)}_minimized.sky.zip | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
+    md5sum "${sky_basename(skyline_zipfile)}_minimized.sky.zip" | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
     """
 }
 
@@ -291,14 +291,14 @@ process SKYLINE_ANNOTATE_DOCUMENT {
     wine SkylineCmd --batch-commands=add_annotations.bat \
         > >(tee 'annotate_doc.stdout') 2> >(tee 'annotate_doc.stderr' >&2)
 
-    md5sum ${sky_basename(skyline_zipfile)}_annotated.sky.zip | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
+    md5sum "${sky_basename(skyline_zipfile)}_annotated.sky.zip" | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
     """
 
     stub:
     """
     touch "${sky_basename(skyline_zipfile)}_annotated.sky.zip"
     touch stub.stdout stub.stderr
-    md5sum ${sky_basename(skyline_zipfile)}_annotated.sky.zip | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
+    md5sum "${sky_basename(skyline_zipfile)}_annotated.sky.zip" | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\1\\t\\2/' > output_file_hashes.txt
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,12 +40,15 @@ params {
     skyline_skyr_file = null
 
     // Optional PDC study settings
-    pdc.client_args = ''
-    pdc.study_id = null
-    pdc.n_raw_files = null
-    pdc.metadata_tsv = null
-    pdc.gene_level_data = null
-    pdc.s3_download = false
+    pdc {
+        client_args = ''
+        study_id = null
+        study_name = null
+        n_raw_files = null
+        metadata_tsv = null
+        gene_level_data = null
+        s3_download = false
+    }
 
     // The final skyline document will be named using this name. For example,
     // if skyline_custom_name = 'human_dia' then the final Skyline document

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -131,6 +131,9 @@
         "study_id": {
           "type": "string"
         },
+        "study_name": {
+          "type": "string"
+        },
         "n_raw_files": {
           "type": "integer"
         },

--- a/subworkflows/get_pdc_files.nf
+++ b/subworkflows/get_pdc_files.nf
@@ -16,7 +16,7 @@ workflow get_pdc_study_metadata {
             metadata = Channel.fromPath(file(params.pdc.metadata_tsv, checkIfExists: true))
             METADATA_TO_SKY_ANNOTATIONS(metadata)
             annotations_csv = METADATA_TO_SKY_ANNOTATIONS.out
-            study_name = params.pdc.study_name
+            study_name = params.pdc.study_name == null ? params.pdc.study_id : params.pdc.study_name
         }
 
     emit:

--- a/subworkflows/get_pdc_files.nf
+++ b/subworkflows/get_pdc_files.nf
@@ -29,20 +29,11 @@ workflow get_pdc_files {
     main:
         get_pdc_study_metadata()
         metadata = get_pdc_study_metadata.out.metadata
-
-		if(params.pdc.s3_download) {
-            metadata
-                .splitJson()
-                .map{ row -> file(row['url']) }
-                .set{ all_paths_ch }
-        } else {
-            metadata
-                .splitJson()
-                .map{ row -> tuple(row['url'], row['file_name'], row['md5sum'], row['file_size']) } \
-                | GET_FILE
-
-            all_paths_ch = GET_FILE.out.downloaded_file
-        }
+        metadata
+            .splitJson()
+            .map{ row -> tuple(row['url'], row['file_name'], row['md5sum'], row['file_size']) } \
+            | GET_FILE
+        all_paths_ch = GET_FILE.out.downloaded_file
 
         all_paths_ch
             .map{ file -> [null, file] }


### PR DESCRIPTION
## Unzipping Bruker .d.zip "files"
* There is at least one study on the PDC where Bruker .d.zip files are nested in multiple parent directories. Apparently, having the submitting lab zip the files in the correct way and re-upload them is not an option.
* `UNZIP_DIRECTORY` was updated to strip empty parent directories above the expected .d directory.
* For example, a .zip archive named `ms_file.d.zip` that unpacks to `/a/bunch/of/parent/directories/ms_file.d/*` will be converted to `ms_file.d/*`

## PDC
* Update pdc_client container to improve the handling of http timeout errors
* Support manually set `params.pdc.metadata_tsv` in either tsv or json format
* Use `params.pdc.study_id` as study name if `params.pdc.study_name` is `null`

## Skyline
* Support Skyline document name with spaces

## Containers
* Update Proteowizard container to latest version of Skyline daily
* Update `qc_pipeline` container to fix PDC gene report
